### PR TITLE
TrainNumberCalcクラスの修正

### DIFF
--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -56,7 +56,7 @@ class TrainNumberCalc {
    *
    * @returns 列車が旅客列車の物の場合、計算した列車種別を返す。列車番号が旅客列車のものではない場合、nullを返す。
    */
-  getPassengerType (): TrainNumberType|null {
+  private getPassengerType (): TrainNumberType|null {
     if (!this.isPassengerNumber()) {
       return null;
     }
@@ -92,7 +92,7 @@ class TrainNumberCalc {
    *
    * @returns 列車が貨物列車の物の場合、計算した列車種別を返す。列車番号が貨物列車のものではない場合、nullを返す。
    */
-  getFreightType (): TrainNumberType|null {
+  private getFreightType (): TrainNumberType|null {
     if (!this.isFreightNumber()) {
       return null;
     }

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -139,7 +139,7 @@ class TrainNumberCalc {
    * 列車番号の千位が6以上の場合は臨時列車
    */
   isPassengerSpecialNumber (): boolean {
-    return this.splitNumber[0] >= 6;
+    return this.isPassengerNumber() && this.splitNumber[0] >= 6;
   }
 
   /**

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -54,9 +54,13 @@ class TrainNumberCalc {
    * - 桁数が3,4桁で、百位が0以外かつ, 下2桁が20~49の場合、客
    * - 千位が6以上の場合、種別の頭に 臨 が付く
    *
-   * @returns 計算した列車種別を返す
+   * @returns 列車が旅客列車の物の場合、計算した列車種別を返す。列車番号が旅客列車のものではない場合、nullを返す。
    */
   getPassengerType (): TrainNumberType|null {
+    if (!this.isPassengerNumber()) {
+      return null;
+    }
+
     const splitNumber = this.splitNumber;
     const isSpecial = this.isPassengerSpecialNumber();
 
@@ -86,9 +90,13 @@ class TrainNumberCalc {
    *     - 下2桁が90~99の場合、専貨B
    * - 千位が8以上の場合、種別の頭に 臨 が付く
    *
-   * @returns 計算した列車種別を返す
+   * @returns 列車が貨物列車の物の場合、計算した列車種別を返す。列車番号が貨物列車のものではない場合、nullを返す。
    */
   getFreightType (): TrainNumberType|null {
+    if (!this.isFreightNumber()) {
+      return null;
+    }
+
     const splitNumber = this.splitNumber;
     const isSpecial = this.isFreightSpecialNumber();
 

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -25,7 +25,7 @@ class TrainNumberCalc {
    */
   constructor (trainNumber: string) {
     this.trainNumber = trainNumber;
-    this.setSplitNumber();
+    this.splitNumber = this.convertToSplitNumber();
   }
 
   /**
@@ -160,10 +160,12 @@ class TrainNumberCalc {
   }
 
   /**
-   * 列車番号を1文字ずつに分割したsplitNumberを設定
+   * 列車番号を1文字ずつに分割したsplitNumberを返すメソッド
+   *
+   * @returns 長さが4以上の配列を返す
    */
-  private setSplitNumber (): void {
-    this.splitNumber = this.trainNumber.toString().padStart(4, '0').split('').map(s => parseInt(s));
+  private convertToSplitNumber (): number[] {
+    return this.trainNumber.toString().padStart(4, '0').split('').map(s => parseInt(s));
   }
 }
 

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -148,7 +148,7 @@ class TrainNumberCalc {
    * 列車番号の千位が8以上の場合は臨時列車
    */
   isFreightSpecialNumber (): boolean {
-    return this.splitNumber[0] >= 8;
+    return this.isFreightNumber() && this.splitNumber[0] >= 8;
   }
 
   /**

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -90,7 +90,7 @@ class TrainNumberCalc {
    */
   getFreightType (): TrainNumberType|null {
     const splitNumber = this.splitNumber;
-    const isSpecial = this.isFreightSpecial();
+    const isSpecial = this.isFreightSpecialNumber();
 
     if (splitNumber[1] === 0) {
       // 高速貨A,B
@@ -147,7 +147,7 @@ class TrainNumberCalc {
    *
    * 列車番号の千位が8以上の場合は臨時列車
    */
-  isFreightSpecial (): boolean {
+  isFreightSpecialNumber (): boolean {
     return this.splitNumber[0] >= 8;
   }
 

--- a/lib/TrainNumberCalc.ts
+++ b/lib/TrainNumberCalc.ts
@@ -58,7 +58,7 @@ class TrainNumberCalc {
    */
   getPassengerType (): TrainNumberType|null {
     const splitNumber = this.splitNumber;
-    const isSpecial = this.isPassengerSpecial();
+    const isSpecial = this.isPassengerSpecialNumber();
 
     if (splitNumber[1] === 0) {
       // 特急客
@@ -138,7 +138,7 @@ class TrainNumberCalc {
    *
    * 列車番号の千位が6以上の場合は臨時列車
    */
-  isPassengerSpecial (): boolean {
+  isPassengerSpecialNumber (): boolean {
     return this.splitNumber[0] >= 6;
   }
 


### PR DESCRIPTION
修正点

- メソッド名の変更
    - `isPassengerSpecial`を`isPassengerSpecialNumber`に変更
    - `isFreightSpecial`を`isFreightSpecialNumber`に変更
- `getPassengerType`メソッドと`getFreightType`メソッドをプライベートメソッドに変更
- `getPassengerType`メソッドと`getFreightType`メソッドの中でそれぞれ種別を確認するように
-  `setSplitNumber`メソッドを`convertToSplitNumber`メソッドに変更し、`splitNumber`の設定はコンストラクタ内で設定