### PR TITLE
QRコード生成に'renderAs'オプションを実装

### DIFF
--- a/components/pages/qr-code/RenderAsField.vue
+++ b/components/pages/qr-code/RenderAsField.vue
@@ -5,27 +5,31 @@
         レンダリング方式
       </label>
 
-      <b-radio
-        v-model="renderAs"
-        name="name"
-        native-value="canvas"
+      <div
+        v-for="(renderAsForm, renderAsFormsKey) in renderAsForms"
+        :key="renderAsFormsKey"
+        class="field"
       >
-        canvas
-      </b-radio>
-
-      <b-radio
-        v-model="renderAs"
-        name="name"
-        native-value="svg"
-      >
-        svg
-      </b-radio>
+        <b-radio
+          :native-value="renderAsForm.value"
+          v-model="renderAs"
+          name="name"
+        >
+          {{ renderAsForm.text }}
+        </b-radio>
+      </div>
     </div>
   </b-field>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { QrCodeRenderAsOptionValue } from '~/types';
+
+interface RenderAsFormOption {
+  value: QrCodeRenderAsOptionValue;
+  text: string;
+}
 
 export default Vue.extend({
   name: 'RenderAsField',
@@ -37,6 +41,12 @@ export default Vue.extend({
       set (renderAs): void {
         this.$store.commit('qrCodeGenerator/setRenderAs', renderAs);
       },
+    },
+    renderAsForms (): RenderAsFormOption[] {
+      return [
+        { value: 'svg', text: 'SVG' },
+        { value: 'canvas', text: 'Canvas' },
+      ];
     },
   },
 });

--- a/components/pages/qr-code/RenderAsField.vue
+++ b/components/pages/qr-code/RenderAsField.vue
@@ -1,0 +1,43 @@
+<template>
+  <b-field>
+    <div class="block">
+      <label class="label">
+        レンダリング方式
+      </label>
+
+      <b-radio
+        v-model="renderAs"
+        name="name"
+        native-value="canvas"
+      >
+        canvas
+      </b-radio>
+
+      <b-radio
+        v-model="renderAs"
+        name="name"
+        native-value="svg"
+      >
+        svg
+      </b-radio>
+    </div>
+  </b-field>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'RenderAsField',
+  computed: {
+    renderAs: {
+      get (): string {
+        return this.$store.state.qrCodeGenerator.renderAs;
+      },
+      set (renderAs): void {
+        this.$store.commit('qrCodeGenerator/setRenderAs', renderAs);
+      },
+    },
+  },
+});
+</script>

--- a/pages/qr-code/index.vue
+++ b/pages/qr-code/index.vue
@@ -32,6 +32,7 @@
           :value="value"
           :size="size"
           :level="level"
+          :render-as="renderAs"
           :background="backGround"
           :foreground="foreGround"
           class="qr-code"
@@ -51,7 +52,7 @@ import ErrorCorrectionLevelField from '~/components/pages/qr-code/ErrorCorrectio
 import RenderAsField from '~/components/pages/qr-code/RenderAsField';
 import BackGroundField from '~/components/pages/qr-code/BackGroundField';
 import ForeGroundField from '~/components/pages/qr-code/ForeGroundField';
-import { QrCodeErrorCorrectionLevel } from '~/types';
+import { QrCodeErrorCorrectionLevel, QrCodeRenderAsOptionValue } from '~/types';
 
 export default Vue.extend({
   head () {
@@ -86,6 +87,9 @@ export default Vue.extend({
     },
     level (): QrCodeErrorCorrectionLevel {
       return this.$store.state.qrCodeGenerator.level;
+    },
+    renderAs (): QrCodeRenderAsOptionValue {
+      return this.$store.state.qrCodeGenerator.renderAs;
     },
     backGround (): string {
       return this.$store.state.qrCodeGenerator.backGround;

--- a/pages/qr-code/index.vue
+++ b/pages/qr-code/index.vue
@@ -18,6 +18,9 @@
           <error-correction-level-field>
           </error-correction-level-field>
 
+          <render-as-field>
+          </render-as-field>
+
           <back-ground-field>
           </back-ground-field>
 
@@ -45,6 +48,7 @@ import QrCodeVue from 'qrcode.vue';
 import ValueField from '~/components/pages/qr-code/ValueField';
 import SizeField from '~/components/pages/qr-code/SizeField';
 import ErrorCorrectionLevelField from '~/components/pages/qr-code/ErrorCorrectionLevelField';
+import RenderAsField from '~/components/pages/qr-code/RenderAsField';
 import BackGroundField from '~/components/pages/qr-code/BackGroundField';
 import ForeGroundField from '~/components/pages/qr-code/ForeGroundField';
 import { QrCodeErrorCorrectionLevel } from '~/types';
@@ -63,6 +67,7 @@ export default Vue.extend({
     ValueField,
     SizeField,
     ErrorCorrectionLevelField,
+    RenderAsField,
     BackGroundField,
     ForeGroundField,
   },

--- a/store/qrCodeGenerator.ts
+++ b/store/qrCodeGenerator.ts
@@ -1,4 +1,4 @@
-import { QrCodeGeneratorState, QrCodeErrorCorrectionLevel } from '~/types';
+import { QrCodeGeneratorState, QrCodeErrorCorrectionLevel, QrCodeRenderAsOptionValue } from '~/types';
 import { MutationTree } from 'vuex';
 
 export const state = (): QrCodeGeneratorState => ({
@@ -19,6 +19,9 @@ export const mutations: MutationTree<QrCodeGeneratorState> = {
   },
   setLevel (state: QrCodeGeneratorState, payload: QrCodeErrorCorrectionLevel): void {
     state.level = payload;
+  },
+  setRenderAs (state: QrCodeGeneratorState, payload: QrCodeRenderAsOptionValue): void {
+    state.renderAs = payload;
   },
   setBackGround (state: QrCodeGeneratorState, payload: string): void {
     state.backGround = payload;

--- a/store/qrCodeGenerator.ts
+++ b/store/qrCodeGenerator.ts
@@ -5,6 +5,7 @@ export const state = (): QrCodeGeneratorState => ({
   value: '',
   size: 250,
   level: 'H',
+  renderAs: 'canvas',
   backGround: '#ffffff',
   foreGround: '#000000',
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ export interface OpenLink extends Link {
 }
 
 export type QrCodeErrorCorrectionLevel = 'L' | 'M' | 'Q' | 'H';
+export type QrCodeRenderAsOptionValue = 'canvas' | 'svg';
 
 export type TrainNumberType = '特急客' | '臨特急客' | '急客' | '臨急客' | '客' | '臨客' |
                               '高速貨A' | '臨高速貨A' | '高速貨B' | '臨高速貨B' | '高速貨C' | '臨高速貨C' |

--- a/types/state.d.ts
+++ b/types/state.d.ts
@@ -24,6 +24,7 @@ export interface QrCodeGeneratorState {
   value: string;
   size: number;
   level: QrCodeErrorCorrectionLevel;
+  renderAs: 'canvas'|'svg';
   backGround: string;
   foreGround: string;
 }

--- a/types/state.d.ts
+++ b/types/state.d.ts
@@ -1,4 +1,4 @@
-import { Link, OpenLink, QrCodeErrorCorrectionLevel } from './index';
+import { Link, OpenLink, QrCodeErrorCorrectionLevel, QrCodeRenderAsOptionValue } from './index';
 
 export interface RootState {
   pageLinks: PageLinksState;
@@ -24,7 +24,7 @@ export interface QrCodeGeneratorState {
   value: string;
   size: number;
   level: QrCodeErrorCorrectionLevel;
-  renderAs: 'canvas'|'svg';
+  renderAs: QrCodeRenderAsOptionValue;
   backGround: string;
   foreGround: string;
 }


### PR DESCRIPTION
QRコード生成に `renderAs` オプションを実装。
`canvas` と `svg` を選択可能。