### PR TITLE
QRコード生成の誤り訂正レベルフィールドでradioボタンを使用

### DIFF
--- a/components/pages/qr-code/ErrorCorrectionLevelField.vue
+++ b/components/pages/qr-code/ErrorCorrectionLevelField.vue
@@ -1,17 +1,24 @@
 <template>
-  <b-field label="誤り訂正レベル">
-    <b-select
-      v-model="level"
-      placeholder="誤り訂正レベルを選択"
-    >
-      <option
+  <b-field>
+    <div class="block">
+      <label class="label">
+        誤り訂正レベル
+      </label>
+
+      <div
         v-for="(errorCorrectionLevel, errorCorrectionLevelsKey) in errorCorrectionLevels"
         :key="errorCorrectionLevelsKey"
-        :value="errorCorrectionLevel.value"
-        v-text="errorCorrectionLevel.text"
+        class="field"
       >
-      </option>
-    </b-select>
+        <b-radio
+          :native-value="errorCorrectionLevel.value"
+          v-model="level"
+          name="name"
+        >
+          {{ errorCorrectionLevel.text }}
+        </b-radio>
+      </div>
+    </div>
   </b-field>
 </template>
 

--- a/components/pages/qr-code/ErrorCorrectionLevelField.vue
+++ b/components/pages/qr-code/ErrorCorrectionLevelField.vue
@@ -6,16 +6,16 @@
       </label>
 
       <div
-        v-for="(errorCorrectionLevel, errorCorrectionLevelsKey) in errorCorrectionLevels"
-        :key="errorCorrectionLevelsKey"
+        v-for="(levelForm, levelFormsKey) in levelForms"
+        :key="levelFormsKey"
         class="field"
       >
         <b-radio
-          :native-value="errorCorrectionLevel.value"
+          :native-value="levelForm.value"
           v-model="level"
           name="name"
         >
-          {{ errorCorrectionLevel.text }}
+          {{ levelForm.text }}
         </b-radio>
       </div>
     </div>
@@ -26,7 +26,7 @@
 import Vue from 'vue';
 import { QrCodeErrorCorrectionLevel } from '~/types';
 
-interface ErrorCorrectionLevelSelects {
+interface ErrorCorrectionLevelFormOption {
   value: QrCodeErrorCorrectionLevel;
   text: string;
 }
@@ -42,7 +42,7 @@ export default Vue.extend({
         this.$store.commit('qrCodeGenerator/setLevel', level);
       },
     },
-    errorCorrectionLevels (): ErrorCorrectionLevelSelects[] {
+    levelForms (): ErrorCorrectionLevelFormOption[] {
       return [
         { value: 'L', text: 'Level L (7%)' },
         { value: 'M', text: 'Level M (15%)' },


### PR DESCRIPTION
QRコード生成の誤り訂正レベルフィールドでradioボタンを使用。
`b-select` から `b-radio` へ切り替え